### PR TITLE
Enable for GNOME 40

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,6 +3,10 @@
    "name": "Notification Banner Position",
    "description": "Changes position of the notification banner from the default to the right side of the screen.",
    "version": 1,
-   "shell-version": [ "3.36" ],
+   "shell-version": [
+      "3.36",
+      "3.38",
+      "40"
+   ],
    "url": "https://github.com/brunodrugowick/notification-position-gnome-extension"
 }


### PR DESCRIPTION
Extension seems to work fine on GNOME 40, but need to update `metadata.json`