### PR TITLE
Add settings-schema to metadata.json for Gnome extension

### DIFF
--- a/src/gnome45/metadata.json
+++ b/src/gnome45/metadata.json
@@ -11,5 +11,6 @@
     "49",
     "50"
   ],
-  "url": "https://github.com/brunodrugowick/notification-position-gnome-extension"
+  "url": "https://github.com/brunodrugowick/notification-position-gnome-extension",
+  "settings-schema": "org.gnome.shell.extensions.notification-position"
 }


### PR DESCRIPTION
This pull request makes a minor update to the `metadata.json` file for the GNOME 45 extension by adding a `settings-schema` key. This enables the extension to specify its settings schema for integration with GNOME's settings system.

#32 